### PR TITLE
chore: fix los cmake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,25 +4,28 @@ project(LaminarOS C CXX)
 
 set(CMAKE_VERBOSE_MAKEFILE ON)
 
+set(LOS_INCLUDES    ${CMAKE_CURRENT_SOURCE_DIR}/LOS_Interface/Inc
+                    ${CMAKE_CURRENT_SOURCE_DIR}/LOS_Core/Inc
+
+                    # Include the config header folder
+                    ${CMAKE_CURRENT_SOURCE_DIR}/LOS_Interface/Common/${FOLDER_NAME}/Inc
+
+                    ## Any new driver folders Inc dirs must be added here ##
+                    ${CMAKE_CURRENT_SOURCE_DIR}/LOS_Driver/RC_Receiver/Inc
+                    ${CMAKE_CURRENT_SOURCE_DIR}/LOS_Driver/Motor_Channel/Inc
+
+                    ${CMAKE_CURRENT_SOURCE_DIR}/boardfiles/${FOLDER_NAME}/Drivers/${FAMILY_NAME}_HAL_Driver/Inc
+                    ${CMAKE_CURRENT_SOURCE_DIR}/boardfiles/${FOLDER_NAME}/Core/Inc
+                    ${CMAKE_CURRENT_SOURCE_DIR}/boardfiles/${FOLDER_NAME}/Drivers/CMSIS/Device/ST/${FAMILY_NAME}/Include
+                    ${CMAKE_CURRENT_SOURCE_DIR}/boardfiles/${FOLDER_NAME}/Drivers/CMSIS/Include
+                    ${CMAKE_CURRENT_SOURCE_DIR}/boardfiles/${FOLDER_NAME}/Middlewares/Third_Party/FreeRTOS/Source
+                    ${CMAKE_CURRENT_SOURCE_DIR}/boardfiles/${FOLDER_NAME}/Middlewares/Third_Party/FreeRTOS/Source/CMSIS_RTOS_V2
+                    ${CMAKE_CURRENT_SOURCE_DIR}/boardfiles/${FOLDER_NAME}/Middlewares/Third_Party/FreeRTOS/Source/portable/GCC/ARM_${PORTABLE_NAME}
+                    ${CMAKE_CURRENT_SOURCE_DIR}/boardfiles/${FOLDER_NAME}/Middlewares/Third_Party/FreeRTOS/Source/include
+)
+message("los includes: ${LOS_INCLUDES}")
 include_directories(
-    ${CMAKE_CURRENT_SOURCE_DIR}/LOS_Interface/Inc
-    ${CMAKE_CURRENT_SOURCE_DIR}/LOS_Core/Inc
-
-    # Include the config header folder
-    ${CMAKE_CURRENT_SOURCE_DIR}/LOS_Interface/Common/${FOLDER_NAME}/Inc
-
-    ## Any new driver folders Inc dirs must be added here ##
-    ${CMAKE_CURRENT_SOURCE_DIR}/LOS_Driver/RC_Receiver/Inc
-    ${CMAKE_CURRENT_SOURCE_DIR}/LOS_Driver/Motor_Channel/Inc
-
-    ${CMAKE_CURRENT_SOURCE_DIR}/boardfiles/${FOLDER_NAME}/Drivers/${FAMILY_NAME}_HAL_Driver/Inc
-    ${CMAKE_CURRENT_SOURCE_DIR}/boardfiles/${FOLDER_NAME}/Core/Inc
-    ${CMAKE_CURRENT_SOURCE_DIR}/boardfiles/${FOLDER_NAME}/Drivers/CMSIS/Device/ST/${FAMILY_NAME}/Include
-    ${CMAKE_CURRENT_SOURCE_DIR}/boardfiles/${FOLDER_NAME}/Drivers/CMSIS/Include
-    ${CMAKE_CURRENT_SOURCE_DIR}/boardfiles/${FOLDER_NAME}/Middlewares/Third_Party/FreeRTOS/Source
-    ${CMAKE_CURRENT_SOURCE_DIR}/boardfiles/${FOLDER_NAME}/Middlewares/Third_Party/FreeRTOS/Source/CMSIS_RTOS_V2
-    ${CMAKE_CURRENT_SOURCE_DIR}/boardfiles/${FOLDER_NAME}/Middlewares/Third_Party/FreeRTOS/Source/portable/GCC/ARM_${PORTABLE_NAME}
-    ${CMAKE_CURRENT_SOURCE_DIR}/boardfiles/${FOLDER_NAME}/Middlewares/Third_Party/FreeRTOS/Source/include
+    ${LOS_INCLUDES}
 )
 
 set(HAL_DRIVERS_DIR ${CMAKE_CURRENT_SOURCE_DIR}/boardfiles/${FOLDER_NAME}/Drivers)
@@ -63,3 +66,7 @@ file(GLOB_RECURSE CXX_SOURCES ${HAL_CORE_CXX_SOURCES}
                               ${CORE_CXX_SOURCES})
 
 add_library(${PROJECT_NAME} ${C_SOURCES} ${CXX_SOURCES})
+
+set_target_properties(${PROJECT_NAME} PROPERTIES
+    LOS_INCLUDES ${LOS_INCLUDES}
+)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,7 +4,7 @@ project(LaminarOS C CXX)
 
 set(CMAKE_VERBOSE_MAKEFILE ON)
 
-set(LOS_INCLUDES    ${CMAKE_CURRENT_SOURCE_DIR}/LOS_Interface/Inc
+set(INCLUDE_PATHS   ${CMAKE_CURRENT_SOURCE_DIR}/LOS_Interface/Inc
                     ${CMAKE_CURRENT_SOURCE_DIR}/LOS_Core/Inc
 
                     # Include the config header folder
@@ -23,9 +23,9 @@ set(LOS_INCLUDES    ${CMAKE_CURRENT_SOURCE_DIR}/LOS_Interface/Inc
                     ${CMAKE_CURRENT_SOURCE_DIR}/boardfiles/${FOLDER_NAME}/Middlewares/Third_Party/FreeRTOS/Source/portable/GCC/ARM_${PORTABLE_NAME}
                     ${CMAKE_CURRENT_SOURCE_DIR}/boardfiles/${FOLDER_NAME}/Middlewares/Third_Party/FreeRTOS/Source/include
 )
-message("los includes: ${LOS_INCLUDES}")
+set(LOS_INCLUDES ${INCLUDE_PATHS} PARENT_SCOPE)
 include_directories(
-    ${LOS_INCLUDES}
+    ${INCLUDE_PATHS}
 )
 
 set(HAL_DRIVERS_DIR ${CMAKE_CURRENT_SOURCE_DIR}/boardfiles/${FOLDER_NAME}/Drivers)
@@ -66,7 +66,3 @@ file(GLOB_RECURSE CXX_SOURCES ${HAL_CORE_CXX_SOURCES}
                               ${CORE_CXX_SOURCES})
 
 add_library(${PROJECT_NAME} ${C_SOURCES} ${CXX_SOURCES})
-
-set_target_properties(${PROJECT_NAME} PROPERTIES
-    LOS_INCLUDES ${LOS_INCLUDES}
-)


### PR DESCRIPTION
I dont know why the diffs are so messed up. 
basically it exports the LOS headers to ZP so that ZP compiles properly with LOS as a library.